### PR TITLE
Support vim-vsnip plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is easy to install and use. It contains these features:
 - [TabNine support](#TabNine-Support). (Highly Recommend!)
 - Easy to install LSP Server with one command
 - Written in pure vim script for vim8 and neovim
-- Snippet support with ultisnips.
+- Snippet support with ultisnips or vim-vsnip.
 - Fast performance
 
 The reason I decided to use pure vim script instead of lua or python is that I want a wider range of compatibility. And I made a lot of async handling with vim script to avoid the block of vim.
@@ -35,6 +35,9 @@ For vim-plug:
 ```vim
 Plug 'jayli/vim-easycomplete'
 Plug 'SirVer/ultisnips'
+" or use vim-vsnip
+Plug 'hrsh7th/vim-vsnip'
+Plug 'hrsh7th/vim-vsnip-integ'
 ```
 
 Run `:PlugInstall`.
@@ -44,6 +47,9 @@ For dein.vim
 ```vim
 call dein#add('jayli/vim-easycomplete')
 call dein#add('SirVer/ultisnips')
+" or use vim-vsnip
+call dein#add('hrsh7th/vim-vsnip')
+call dein#add('hrsh7th/vim-vsnip-integ')
 ```
 
 For Packer.nvim
@@ -51,6 +57,9 @@ For Packer.nvim
 ```lua
 use { 'jayli/vim-easycomplete' }
 use { 'SirVer/ultisnips' }
+-- or use vim-vsnip
+use { 'hrsh7th/vim-vsnip' }
+use { 'hrsh7th/vim-vsnip-integ' }
 ```
 
 ### All Supported Commands
@@ -140,6 +149,7 @@ All supported languages:
 | directory   | directory | No Need                  | Integrated         | None         | -                         |
 | buf         | buf & dict| No Need                  | Integrated         | None         | -                         |
 | snips       | Snippets  | ultisnips                | Integrated         | python3      | -                         |
+| vsnip       | Snippets  | vim-vsnip                | Integrated         | None         | -                         |
 | ts          | js/ts     | tsserver                 | Yes                | node/npm     | Yes                       |
 | deno        | js/ts     | denols                   | Yes                | deno         | Yes                       |
 | tn          | TabNine   | TabNine                  | Yes                | None         | No                        |
@@ -209,7 +219,7 @@ let g:easycomplete_filetypes = {
 
 #### Snippet Support
 
-Vim-EasyComplete does not support snippets by default. If you want snippet integration, you will first have to install `ultisnips`. UltiSnips is compatible with Vim-EasyComplete out of the box. UltiSnips required python3 installed.
+Vim-EasyComplete does not support snippets by default. If you want snippet integration, you will first have to install `ultisnips` or `vim-vsnip`. UltiSnips and Vsnip are compatible with Vim-EasyComplete out of the box. UltiSnips required python3 installed.
 
 > [Solution of "E319: No python3 provider found" Error in neovim 0.4.4 with ultisnips](https://github.com/jayli/vim-easycomplete/issues/171)
 

--- a/autoload/easycomplete.vim
+++ b/autoload/easycomplete.vim
@@ -1633,6 +1633,10 @@ function! s:SnippetsInit()
   endif
 endfunction
 
+function! easycomplete#VsnipSupports() abort
+  return exists('*vsnip#get_complete_items') == 1
+endfunction
+
 function! easycomplete#nill() abort
   return ''
 endfunction

--- a/autoload/easycomplete/sources/vsnip.vim
+++ b/autoload/easycomplete/sources/vsnip.vim
@@ -1,0 +1,62 @@
+function! easycomplete#sources#vsnip#completor(opt, ctx) abort
+  if !easycomplete#VsnipSupports()
+    call easycomplete#complete(a:opt['name'], a:ctx, a:ctx['startcol'], [])
+    return v:true
+  endif
+  if index(['.', '/', ':'], a:ctx['char']) >= 0
+    call easycomplete#complete(a:opt['name'], a:ctx, a:ctx['startcol'], [])
+    return v:true
+  endif
+  let l:typing = a:ctx['typing']
+  if strlen(l:typing) == 0
+    call easycomplete#complete(a:opt['name'], a:ctx, a:ctx['startcol'], [])
+    return v:true
+  endif
+  if len(matchstr(a:ctx['line'], s:GetKeywordPattern() . '$')) < 1
+    call easycomplete#complete(a:opt['name'], a:ctx, a:ctx['startcol'], [])
+    return v:true
+  endif
+  call easycomplete#util#AsyncRun(
+        \ function('s:CompleteHandler'),
+        \ [l:typing, a:opt['name'], a:ctx, a:ctx['startcol']],
+        \ 1)
+  return v:true
+endfunction
+
+function! s:CompleteHandler(typing, name, ctx, startcol) abort
+  let suggestions = vsnip#get_complete_items(a:ctx['bufnr'])
+  for snippet in suggestions
+    let menu = substitute(snippet.menu, '^\[.*\] ', '', '')
+    call extend(snippet, {
+          \ 'abbr': snippet.abbr . '~',
+          \ 'kind': g:easycomplete_kindflag_vsnip,
+          \ 'menu': g:easycomplete_menuflag_vsnip . ' ' . menu,
+          \ 'info': ['Snippet: ' . menu, '-----'] + json_decode(snippet.user_data).vsnip.snippet,
+          \ })
+  endfor
+  call easycomplete#complete(a:name, a:ctx, a:startcol, suggestions)
+endfunction
+
+function! easycomplete#sources#vsnip#constructor(...) abort
+  " Do Nothing
+endfunction
+
+function! s:GetKeywordPattern() abort
+  let l:keywords = split(&iskeyword, ',')
+  let l:keywords = filter(l:keywords, { _, k -> match(k, '\d\+-\d\+') == -1 })
+  let l:keywords = filter(l:keywords, { _, k -> k !=# '@' })
+  let l:pattern = '\%(' . join(map(l:keywords, { _, v -> '\V' . escape(v, '\') . '\m' }), '\|') . '\|\w\)*'
+  return l:pattern
+endfunction
+
+function! s:log(...) abort
+  return call('easycomplete#util#log', a:000)
+endfunction
+
+function! s:once(...) abort
+  return call('easycomplete#util#once', a:000)
+endfunction
+
+function! s:console(...) abort
+  return call('easycomplete#log#log', a:000)
+endfunction

--- a/doc/easycomplete.txt
+++ b/doc/easycomplete.txt
@@ -21,7 +21,7 @@ Vim-Easycomplete is easy to install and use. It contains these features:
 - LSP support
 - Easy to install LSP Server with one command
 - Written in pure vim script for vim8 and neovim
-- Snippet support with ultisnips.
+- Snippet support with ultisnips or vim-vsnip.
 - Brand New UI Design.
 
 ==============================================================================
@@ -130,6 +130,7 @@ All supported languages:
 | directory   | directory suggestion  | No Need                | No Need   |
 | buf         | keywords & dictionary | No Need                | No Need   |
 | snips       | Snippets Support      | ultisnips/vim-snippets | No        |
+| vsnip       | Snippets Support      | vim-vsnip              | No        |
 | ts          | JavaScript/TypeScript | tsserver               | Yes       |
 | deno        | JavaScript/TypeScript | deno                   | Yes       |
 | tn          | TabNine               | TabNine                | Yes       |
@@ -155,11 +156,14 @@ All supported languages:
 | php         | php                   | intelephense           | Yes       |
 | cs          | C#                    | omnisharp-lsp          | Yes       |
 
-EasyComplete needs ultisnips for snippets support if you want.
-This plugin is compatible with Vim-EasyComplete out of the box. Install with
+EasyComplete needs ultisnips or vim-vsnip for snippets support if you want.
+These plugins are compatible with Vim-EasyComplete out of the box. Install with
 vim-plug: >
 
   Plug 'SirVer/ultisnips'
+  " or
+  Plug 'hrsh7th/vim-vsnip'
+  Plug 'hrsh7th/vim-vsnip-integ'
 <
 
 Install TabNine language server: `InstallLspServer tabnine` or `InstallLspServer tn`
@@ -196,6 +200,8 @@ via these configurations:
 - Set `let g:easycomplete_kindflag_dict = ''` for dictionary kind flag.
 - Set `let g:easycomplete_menuflag_snip = '[S]'` for snippets menu flag.
 - Set `let g:easycomplete_kindflag_snip = 's'` for snippets kind flag.
+- Set `let g:easycomplete_menuflag_vsnip = '[VS]'` for snippets menu flag.
+- Set `let g:easycomplete_kindflag_vsnip = 's'` for snippets kind flag.
 - Set `let g:easycomplete_kindflag_tabnine = ''` for TabNine kind flag.
 - Set `let g:easycomplete_lsp_type_font = {...}` for custom fonts.
 
@@ -205,6 +211,8 @@ Example configuration with <https://nerdfonts.com>: >
   let g:easycomplete_kindflag_buf = "⚯"
   let g:easycomplete_menuflag_snip = ""
   let g:easycomplete_kindflag_snip = "ട"
+  let g:easycomplete_menuflag_vsnip = ""
+  let g:easycomplete_kindflag_vsnip = "ട"
   let g:easycomplete_kindflag_dict = "≡"
   let g:easycomplete_menuflag_dict = ""
   let g:easycomplete_kindflag_tabnine = ""

--- a/plugin/easycomplete.vim
+++ b/plugin/easycomplete.vim
@@ -33,6 +33,10 @@ let g:easycomplete_menuflag_snip = empty(   easycomplete#util#get(g:easycomplete
                                   \ "[S]" : easycomplete#util#get(g:easycomplete_menu_skin, "snip", "menu")
 let g:easycomplete_kindflag_snip = empty(   easycomplete#util#get(g:easycomplete_menu_skin, "snip", "kind")) ?
                                   \ "s" :   easycomplete#util#get(g:easycomplete_menu_skin, "snip", "kind")
+let g:easycomplete_menuflag_vsnip = empty(   easycomplete#util#get(g:easycomplete_menu_skin, "vsnip", "menu")) ?
+                                  \ "[VS]" : easycomplete#util#get(g:easycomplete_menu_skin, "vsnip", "menu")
+let g:easycomplete_kindflag_vsnip = empty(   easycomplete#util#get(g:easycomplete_menu_skin, "vsnip", "kind")) ?
+                                  \ "s" :   easycomplete#util#get(g:easycomplete_menu_skin, "vsnip", "kind")
 let g:easycomplete_menuflag_tabnine = empty(easycomplete#util#get(g:easycomplete_menu_skin, "tabnine", "menu")) ?
                                   \ "[TN]": easycomplete#util#get(g:easycomplete_menu_skin, "tabnine", "menu")
 let g:easycomplete_kindflag_tabnine = empty(easycomplete#util#get(g:easycomplete_menu_skin, "tabnine", "kind")) ?
@@ -419,6 +423,12 @@ augroup easycomplete#PluginRegister
       \ 'whitelist': ['*'],
       \ 'completor': 'easycomplete#sources#snips#completor',
       \ })
+
+  au User easycomplete_default_plugin call easycomplete#RegisterSource({
+      \ 'name': 'vsnip',
+      \ 'whitelist': ['*'],
+      \ 'completor': 'easycomplete#sources#vsnip#completor',
+      \ })
 augroup END
 
 augroup easycomplete#NormalBinding
@@ -464,8 +474,8 @@ inoremap <expr> <CR> easycomplete#TypeEnterWithPUM()
 inoremap <expr> <Up> easycomplete#Up()
 inoremap <expr> <Down> easycomplete#Down()
 " inoremap <expr> <BS> easycomplete#BackSpace()
-inoremap <silent> <Plug>EasycompleteTabTrigger <c-r>=seasycomplete#CleverTab()<cr>
-inoremap <silent> <Plug>EasycompleteShiftTabTrigger <c-r>=seasycomplete#CleverShiftTab()<cr>
+inoremap <silent> <Plug>EasycompleteTabTrigger <c-r>=easycomplete#CleverTab()<cr>
+inoremap <silent> <Plug>EasycompleteShiftTabTrigger <c-r>=easycomplete#CleverShiftTab()<cr>
 inoremap <silent> <Plug>EasycompleteRefresh <C-r>=easycomplete#refresh()<CR>
 inoremap <silent> <Plug>EasycompleteNill <C-r>=easycomplete#nill()<CR>
 inoremap <silent> <Plug>EasycompleteExpandSnippet  <C-R>=UltiSnips#ExpandSnippet()<cr>


### PR DESCRIPTION
Hi @jayli ,

I am adding vsnip source to support [vim-vsnip](https://github.com/hrsh7th/vim-vsnip) plugin.

Snippets in Completion Menu

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/438791/223725654-f04b4d60-d165-44e8-96de-9acf7df9ec8d.png">

Snippet is expanded on pressing Enter
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/438791/223725729-bd037fba-773a-40db-a4e6-929e4f35b23c.png">

I'm not sure I should add this integration to vim-easycomplete or vim-vsnip.
Please help review and merge it if you see it does make senses Thanks.
