### PR TITLE
添加 输入n个字才开始提示的 设置, 可以避免顿卡

### DIFF
--- a/autoload/easycomplete.vim
+++ b/autoload/easycomplete.vim
@@ -1206,7 +1206,7 @@ function! s:CompleteHandler()
   if &filetype == "json"
     call extend(l:checking, ['"'])
   endif
-  if strwidth(l:ctx['typing']) == 0 && index(l:checking, l:ctx['char']) < 0
+  if strwidth(l:ctx['typing']) < g:easycomplete_behaviorKeywordLength && index(l:checking, l:ctx['char']) < 0
     return
   endif
   " 以上所有步骤都是特殊情况的拦截，后续逻辑应当完全交给 LSP 插件来做标准处

--- a/plugin/easycomplete.vim
+++ b/plugin/easycomplete.vim
@@ -71,6 +71,12 @@ endif
 if !exists("g:easycomplete_colorful")
   let g:easycomplete_colorful= 0
 endif
+
+" 输入n个字才开始提示,可以避免字符输入的顿卡
+if !exists("g:easycomplete_behaviorKeywordLength")
+  let g:easycomplete_behaviorKeywordLength = 2
+endif
+
 let g:easycomplete_config = {
       \ 'g:easycomplete_diagnostics_hover':  1,
       \ 'g:easycomplete_diagnostics_enable': 1,


### PR DESCRIPTION
let g:easycomplete_behaviorKeywordLength = 2
默认输入2个字才开始提示, 这是修正提示顿卡比较关键的一步, 开始输入set都不会卡了.