### PR TITLE
Disable foldenable in Snippet preview popup/float

### DIFF
--- a/autoload/easycomplete/popup.vim
+++ b/autoload/easycomplete/popup.vim
@@ -403,6 +403,7 @@ function! s:VimShow(opt, windowtype, float_type)
     " call setwinvar(winid, '&wrap', 1)
     " call setwinvar(winid, '&linebreak', 1)
     " call setwinvar(winid, '&conceallevel', 2)
+    call setwinvar(winid, '&foldenable', 0)
   endif
   " Popup and Signature
   if a:windowtype == 'popup'
@@ -445,6 +446,7 @@ function! s:NVimShow(opt, windowtype, float_type)
   call nvim_win_set_option(g:easycomplete_popup_win[a:windowtype], 'cursorline', v:false)
   call nvim_win_set_option(g:easycomplete_popup_win[a:windowtype], 'cursorcolumn', v:false)
   call nvim_win_set_option(g:easycomplete_popup_win[a:windowtype], 'colorcolumn', '')
+  call nvim_win_set_option(g:easycomplete_popup_win[a:windowtype], 'foldenable', v:false)
   if has('nvim-0.5.0')
     call setwinvar(g:easycomplete_popup_win[a:windowtype], '&scrolloff', 0)
   endif


### PR DESCRIPTION
Snippet with multiple lines are folded. This issue happened with vsnip snippet, but I think it maybe happen with ultisnip snippet as well.

Before:
<img width="891" alt="image" src="https://github.com/jayli/vim-easycomplete/assets/438791/6d9ed2d3-eecc-42b1-a346-df54bb144aa2">

After:
<img width="876" alt="image" src="https://github.com/jayli/vim-easycomplete/assets/438791/7caa1092-fbef-4dc2-9f50-8a11ee41ef3a">


Please help to review this PR, thanks.
