### PR TITLE
bugfix. nvim_set_hl cannot recognize numeric ctermfg val in string type

### DIFF
--- a/autoload/easycomplete/ui.vim
+++ b/autoload/easycomplete/ui.vim
@@ -78,20 +78,20 @@ endfunction "}}}
 function! easycomplete#ui#GetHiColor(hiName, sufix)
   let sufix = empty(a:sufix) ? "bg" : a:sufix
   let hlString = easycomplete#ui#HighlightArgs(a:hiName)
-  if empty(hlString) | return "NONE" | endif
+  let my_color = "NONE"
+  if empty(hlString) | return my_color | endif
   if easycomplete#util#IsGui()
     " Gui color name
     let my_color = matchstr(hlString,"\\(\\sgui" . sufix . "=\\)\\@<=#\\w\\+")
-    if my_color != ''
-      return my_color
-    endif
   else
     let my_color= matchstr(hlString,"\\(\\scterm" .sufix. "=\\)\\@<=\\w\\+")
-    if my_color!= ''
-      return my_color
-    endif
   endif
-  return 'NONE'
+
+  if my_color =~ '^\d\+$'
+      return str2nr(my_color)
+  endif
+
+  return my_color
 endfunction " }}}
 
 " Hilight {{{

--- a/lua/easycomplete/tabnine.lua
+++ b/lua/easycomplete/tabnine.lua
@@ -9,7 +9,7 @@ function Export.nvim_init_tabnine_hl()
   local linenr_fg = vim.fn["easycomplete#ui#GetFgColor"]("LineNr")
   vim.api.nvim_set_hl(0, "TabNineSuggestionFirstLine", {
     bg = cursorline_bg,
-    fg = linenr_fg,
+    fg = linenr_fg
   })
   vim.api.nvim_set_hl(0, "TabNineSuggestionNoneFirstLine", {
     fg = linenr_fg,


### PR DESCRIPTION
![image](https://github.com/jayli/vim-easycomplete/assets/49359615/2d81ec8d-accf-44a2-bd6b-6f8c8fed626f)
在我的WSL环境上安装vim-easycomplete插件后，遇到了如下错误提示，调试后发现是由于`vim.api.nvim_set_hl`接口无法识别字符串类型的ctermfg数值.
![image](https://github.com/jayli/vim-easycomplete/assets/49359615/a7994312-ccb8-4d17-9cea-8714a938ea92)
![image](https://github.com/jayli/vim-easycomplete/assets/49359615/519ae013-de5a-41e6-8116-ea3c7e703ecb)
于是对`easycomplete#ui#GetHiColor`接口的返回值进行修改，当匹配到ctermfg的值为全数字时，返回数值类型的值，修改后，不再报错，且调试输出符合预期
![image](https://github.com/jayli/vim-easycomplete/assets/49359615/7eb55009-bae3-47ac-bfe3-78a79eb5a034)
